### PR TITLE
Limit max download size

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -164,12 +164,16 @@ class ApplicationController < ActionController::Base
 
   # @return true if the object is too large even for async download, false otherwise
   def exceeds_download_size(object)
-    return (object.total_actual_size > APP_CONFIG['max_archive_size'])
+    return (object.total_actual_size > APP_CONFIG['max_download_size'])
   end
 
   # @return true if the version is too large even for async download, false otherwise
   def exceeds_download_size_version(version)
-    return (version.total_actual_size > APP_CONFIG['max_archive_size'])
+    return (version.total_actual_size > APP_CONFIG['max_download_size'])
+  end
+
+  def max_download_size_pretty
+    @max_download_size_pretty ||= number_to_storage_size(APP_CONFIG['max_download_size'])
   end
 
   def store_location

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -152,11 +152,13 @@ class ApplicationController < ActionController::Base
     @_current_group ||= Group.find(session[:group_id])
   end
 
-  def exceeds_size(object)
+  # @return true if the object is too large for synchronous download, false otherwise
+  def exceeds_sync_size(object)
     return (object.total_actual_size > APP_CONFIG['max_archive_size'])
   end
 
-  def exceeds_size_version(version)
+  # @return true if the version is too large for synchronous download, false otherwise
+  def exceeds_sync_size_version(version)
     return (version.total_actual_size > APP_CONFIG['max_archive_size'])
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -162,6 +162,16 @@ class ApplicationController < ActionController::Base
     return (version.total_actual_size > APP_CONFIG['max_archive_size'])
   end
 
+  # @return true if the object is too large even for async download, false otherwise
+  def exceeds_download_size(object)
+    return (object.total_actual_size > APP_CONFIG['max_archive_size'])
+  end
+
+  # @return true if the version is too large even for async download, false otherwise
+  def exceeds_download_size_version(version)
+    return (version.total_actual_size > APP_CONFIG['max_archive_size'])
+  end
+
   def store_location
     session[:return_to] = request.fullpath
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -172,6 +172,11 @@ class ApplicationController < ActionController::Base
     return (version.total_actual_size > APP_CONFIG['max_download_size'])
   end
 
+  # @return true if the file is too large for download, false otherwise
+  def exceeds_download_size_file(file)
+    return (file.full_size > APP_CONFIG['max_download_size'])
+  end
+
   def max_download_size_pretty
     @max_download_size_pretty ||= number_to_storage_size(APP_CONFIG['max_download_size'])
   end

--- a/app/controllers/file_controller.rb
+++ b/app/controllers/file_controller.rb
@@ -18,12 +18,16 @@ class FileController < ApplicationController
   end
   
   def download
-    stream_response(@file.bytestream_uri, 
-                    "inline",
-                    File.basename(@file.pathname), 
-                    @file.mime_type,
-                    @file.full_size)
-  end 
+    if exceeds_download_size_file(@file)
+      render :file => "#{Rails.root}/public/403.html", :status => 403, :layout => false
+    else
+      stream_response(@file.bytestream_uri,
+                      "inline",
+                      File.basename(@file.pathname),
+                      @file.mime_type,
+                      @file.full_size)
+    end
+  end
   
   private
   def load_file

--- a/app/controllers/object_controller.rb
+++ b/app/controllers/object_controller.rb
@@ -25,8 +25,10 @@ class ObjectController < ApplicationController
     # Interactive large object download does not support userFriendly
     # Call controller directly
 
-    # if size is > max_archive_size, redirect to have user enter email for asynch compression (skipping streaming)
-    if exceeds_sync_size(@object) then
+    if exceeds_download_size(@object) then
+      render :file => "#{Rails.root}/public/403.html", :status => 403, :layout => false
+    elsif exceeds_sync_size(@object) then
+      # if size is > max_archive_size, redirect to have user enter email for asynch compression (skipping streaming)
       redirect_to(:controller => "lostorage", :action => "index", :object => @object)
     end
   end
@@ -184,7 +186,9 @@ class ObjectController < ApplicationController
   end
 
   def async
-    if exceeds_sync_size(@object) then
+    if exceeds_download_size(@object) then
+      render :nothing => true, :status => 403
+    elsif exceeds_sync_size(@object) then
       # Async Supported
       render :nothing => true, :status => 200
     else

--- a/app/controllers/object_controller.rb
+++ b/app/controllers/object_controller.rb
@@ -25,8 +25,8 @@ class ObjectController < ApplicationController
     # Interactive large object download does not support userFriendly
     # Call controller directly
 
-    # if size is > 4GB, redirect to have user enter email for asynch compression (skipping streaming)
-    if exceeds_size(@object) then
+    # if size is > max_archive_size, redirect to have user enter email for asynch compression (skipping streaming)
+    if exceeds_sync_size(@object) then
       redirect_to(:controller => "lostorage", :action => "index", :object => @object)
     end
   end
@@ -184,7 +184,7 @@ class ObjectController < ApplicationController
   end
 
   def async
-    if exceeds_size(@object) then
+    if exceeds_sync_size(@object) then
       # Async Supported
       render :nothing => true, :status => 200
     else

--- a/app/controllers/version_controller.rb
+++ b/app/controllers/version_controller.rb
@@ -17,9 +17,9 @@ class VersionController < ApplicationController
   end
 
   before_filter(:only => [:download, :downloadUser]) do
-    # if size is > 4GB, redirect to have user enter email for asynch
+    # if size is > max_archive_size, redirect to have user enter email for asynch
     # compression (skipping streaming)
-    if exceeds_size_version(@version) then
+    if exceeds_sync_size_version(@version) then
       redirect_to(:controller => "lostorage", 
                   :action     => "index", 
                   :object     => @version.inv_object, 
@@ -40,7 +40,7 @@ class VersionController < ApplicationController
   end
 
  def async
-    if exceeds_size_version(@version) then
+    if exceeds_sync_size_version(@version) then
       # Async Supported
       render :nothing => true, :status => 200
     else

--- a/app/controllers/version_controller.rb
+++ b/app/controllers/version_controller.rb
@@ -17,10 +17,12 @@ class VersionController < ApplicationController
   end
 
   before_filter(:only => [:download, :downloadUser]) do
-    # if size is > max_archive_size, redirect to have user enter email for asynch
-    # compression (skipping streaming)
-    if exceeds_sync_size_version(@version) then
-      redirect_to(:controller => "lostorage", 
+    if exceeds_download_size_version(@version) then
+      render :file => "#{Rails.root}/public/403.html", :status => 403, :layout => false
+    elsif exceeds_sync_size_version(@version) then
+      # if size is > max_archive_size, redirect to have user enter email for asynch
+      # compression (skipping streaming)
+      redirect_to(:controller => "lostorage",
                   :action     => "index", 
                   :object     => @version.inv_object, 
                   :version    => @version)
@@ -40,7 +42,9 @@ class VersionController < ApplicationController
   end
 
  def async
-    if exceeds_sync_size_version(@version) then
+   if exceeds_download_size_version(@version) then
+     render :nothing => true, :status => 403
+   elsif exceeds_sync_size_version(@version) then
       # Async Supported
       render :nothing => true, :status => 200
     else

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -6,36 +6,6 @@ module ApplicationHelper
     else i.to_s.gsub!(/(\d)(?=(\d\d\d)+(?!\d))/, "\\1,") end
   end
 
-  # Modeled after the rails helper that does all sizes in binary representations
-  # but gives sizes in decimal instead with 1kB = 1,000 Bytes, 1 MB = 1,000,000 bytes
-  # etc.
-  #
-  # Formats the bytes in +size+ into a more understandable representation.
-  # Useful for reporting file sizes to users. This method returns nil if
-  # +size+ cannot be converted into a number. You can change the default
-  # precision of 1 in +precision+.
-  #
-  #  number_to_storage_size(123)           => 123 Bytes
-  #  number_to_storage_size(1234)          => 1.2 kB
-  #  number_to_storage_size(12345)         => 12.3 kB
-  #  number_to_storage_size(1234567)       => 1.2 MB
-  #  number_to_storage_size(1234567890)    => 1.2 GB
-  #  number_to_storage_size(1234567890123) => 1.2 TB
-  #  number_to_storage_size(1234567, 2)    => 1.23 MB
-  def number_to_storage_size(size, precision=1)
-    size = Kernel.Float(size)
-    case
-      when size == 1 then "1 Byte"
-      when size < 10**3 then "%d B" % size
-      when size < 10**6 then "%.#{precision}f KB"  % (size / 10.0**3)
-      when size < 10**9 then "%.#{precision}f MB"  % (size / 10.0**6)
-      when size < 10**12 then "%.#{precision}f GB"  % (size / 10.0**9)
-      else                    "%.#{precision}f TB"  % (size / 10.0**12)
-    end.sub('.0', '')
-  rescue
-    nil
-  end
-
   def permissions(array)
     if (array.length == 0) then "none"
     elsif (array.length == 1) then "#{array[0]} only"

--- a/app/views/file/_line_sidebar.html.erb
+++ b/app/views/file/_line_sidebar.html.erb
@@ -2,13 +2,17 @@
 <% version = file.inv_version %>
 <% object = version.inv_object %>
 <li style="word-wrap:break-word;">
-  <% if (can_download) then %>
-    <%= link_to File.basename(file.pathname),
+  <% if can_download %>
+    <% if exceeds_download_size_file(file) %>
+      <%= File.basename(file.pathname) %> (too large to download)
+    <% else %>
+      <%= link_to File.basename(file.pathname),
           :controller       => :file,
           :action           => :download,
           :object           => object,
           :version          => version,
           :file             => file %>
+    <% end %>
   <% else %>
     <%= File.basename(file.pathname) %>
   <% end %>

--- a/app/views/object/index.html.erb
+++ b/app/views/object/index.html.erb
@@ -21,7 +21,10 @@
   <div class="key">&nbsp;</div><div class="value">&nbsp;</div>
   <div class="key">&nbsp;</div>
   <div class="value">
-    <% if has_object_permission?(@object, 'download') then %>
+    <% if exceeds_download_size(@object) %>
+      Objects larger than <%= max_download_size_pretty %> cannot be downloaded as a .zip file.
+      Versions and individual files below that size can still be downloaded.
+    <% elsif has_object_permission?(@object, 'download') then %>
       <form action="<%= url_for(:action=>:download, :object => @object) %>">
         <input type="submit" value="Download object">
       </form>

--- a/app/views/version/_files.html.erb
+++ b/app/views/version/_files.html.erb
@@ -8,29 +8,29 @@
     <% object_id = object.to_param %>
     <%# would be cleaner code if we had this check inside the
         file.each but it is slower for pages with many files %>
-    <% if has_object_permission?(object, 'download') %>
-      <% files.each do |file| %>
-        <div class="key">
+    <% can_download_object = has_object_permission?(object, 'download') %>
+    <% files.each do |file| %>
+      <%
+        file_basename = File.basename(file.pathname)
+        file_too_large = exceeds_download_size_file(file)
+      %>
+      <div class="key">
+        <% if can_download_object && !file_too_large %>
           <%# not using link_to speeds this up %>
           <a href="/d/<%= object_id %>/<%= version_id %>/<%= file.to_param %>">
-            <%= File.basename(file.pathname) %>
+            <%= file_basename %>
           </a>
-        </div>
-        <div class="value">
-          <%= clean_mime_type(file.mime_type) %>       
-          <%= number_to_storage_size(file.full_size) %>
-        </div>
-      <% end %>
-    <% else %>
-      <% files.each do |file| %>
-        <div class="key">
-          <%= File.basename(file.pathname) %>
-        </div>
-        <div class="value">
-          <%= clean_mime_type(file.mime_type) %>       
-          <%= number_to_storage_size(file.full_size) %>
-        </div>
-      <% end %>
+        <% else %>
+          <%= file_basename %>
+        <% end %>
+      </div>
+      <div class="value">
+        <%= clean_mime_type(file.mime_type) %>
+        <%= number_to_storage_size(file.full_size) %>
+        <% if file_too_large %>
+          <br/>&nbsp;(too large to download)
+        <% end %>
+      </div>
     <% end %>
   <% end %>
 </div>

--- a/app/views/version/_files.html.erb
+++ b/app/views/version/_files.html.erb
@@ -9,10 +9,14 @@
     <%# would be cleaner code if we had this check inside the
         file.each but it is slower for pages with many files %>
     <% can_download_object = has_object_permission?(object, 'download') %>
+    <% any_file_too_large = false %>
     <% files.each do |file| %>
       <%
         file_basename = File.basename(file.pathname)
         file_too_large = exceeds_download_size_file(file)
+        if file_too_large
+          any_file_too_large = true
+        end
       %>
       <div class="key">
         <% if can_download_object && !file_too_large %>
@@ -27,9 +31,16 @@
       <div class="value">
         <%= clean_mime_type(file.mime_type) %>
         <%= number_to_storage_size(file.full_size) %>
-        <% if file_too_large %>
-          <br/>&nbsp;(too large to download)
-        <% end %>
+      </div>
+    <% end %>
+    <% if any_file_too_large %>
+      <div class="key">&nbsp;</div>
+      <div class="value">&nbsp;</div>
+      <div class="key">&nbsp;</div>
+      <div class="value">
+        Files larger than <%= max_download_size_pretty %> cannot be downloaded.
+        For access to large files, please
+        <a href="http://www.cdlib.org/services/uc3/contact.html">contact UC3</a>.
       </div>
     <% end %>
   <% end %>

--- a/app/views/version/index.html.erb
+++ b/app/views/version/index.html.erb
@@ -38,16 +38,16 @@
 
   <div class="key">&nbsp;</div><div class="value">&nbsp;</div>
   <div class="key">&nbsp;</div>
-<% if exceeds_download_size_version(@version) %>
-  Versions larger than <%= max_download_size_pretty %> cannot be downloaded as a .zip file.
-  Versions and individual files below that size can still be downloaded.
-<% elsif has_object_permission?(@version.inv_object, 'download') then %>
   <div class="value">
-    <form action="<%= url_for(:action=>:download, :object=> @version.inv_object, :version => @version) %>">
-      <input type="submit" value="Download version">
-    </form>
+    <% if exceeds_download_size_version(@version) %>
+      Versions larger than <%= max_download_size_pretty %> cannot be downloaded as a .zip file.
+      Versions and individual files below that size can still be downloaded.
+    <% elsif has_object_permission?(@version.inv_object, 'download') then %>
+      <form action="<%= url_for(:action=>:download, :object=> @version.inv_object, :version => @version) %>">
+        <input type="submit" value="Download version">
+      </form>
+    <% end %>
   </div>
-<% end %>
 </div>
 <div class="grid_1">&nbsp;</div>
 <div class="grid_4 sidebar">

--- a/app/views/version/index.html.erb
+++ b/app/views/version/index.html.erb
@@ -38,7 +38,10 @@
 
   <div class="key">&nbsp;</div><div class="value">&nbsp;</div>
   <div class="key">&nbsp;</div>
-<% if has_object_permission?(@version.inv_object, 'download') then %>
+<% if exceeds_download_size_version(@version) %>
+  Versions larger than <%= max_download_size_pretty %> cannot be downloaded as a .zip file.
+  Versions and individual files below that size can still be downloaded.
+<% elsif has_object_permission?(@version.inv_object, 'download') then %>
   <div class="value">
     <form action="<%= url_for(:action=>:download, :object=> @version.inv_object, :version => @version) %>">
       <input type="submit" value="Download version">

--- a/config/app_config.yml
+++ b/config/app_config.yml
@@ -1,5 +1,5 @@
 defaults: &defaults
-  # maximum byte size threshhold for download of object/versions without compression
+  # maximum byte size threshold for download of object/versions without compression
   max_archive_size:     1073741824  # 1073741824 bytes = 1 GiB
   # maximum byte size threshold for any download whatsoever
   max_download_size:    322122547200  # 322122547200 bytes = 300 GiB

--- a/config/app_config.yml
+++ b/config/app_config.yml
@@ -9,7 +9,7 @@ defaults: &defaults
 development: &development
   <<: *defaults
   max_archive_size:     536870912  # 536870912 bytes = 512 MiB
-  max_download_size:    161061273600  # 161061273600 bytes = 150 GiB
+  max_download_size:    5368709120  # 5368709120 bytes = 5 GiB
   dua_email_to:         [marisa.strong@ucop.edu]
   lostorage_email_to:   [marisa.strong@ucop.edu]
   lostorage_email_from: marisa.strong@ucop.edu
@@ -59,6 +59,6 @@ production_development:
 test:
   <<: *development
   max_archive_size:  999999  # 999999 bytes ~= 976.6 KiB
-  max_download_size: 104857600  # 104857600 bytes = 100 MiB
+  max_download_size: 104857600  # 10485760 bytes = 10 MiB
 local:
   <<: *development

--- a/config/app_config.yml
+++ b/config/app_config.yml
@@ -1,12 +1,15 @@
 defaults: &defaults
-  #maximum byte size threshhold for download of object/versions without compression 
-  max_archive_size:     1073741824
+  # maximum byte size threshhold for download of object/versions without compression
+  max_archive_size:     1073741824  # 1073741824 bytes = 1 GiB
+  # maximum byte size threshold for any download whatsoever
+  max_download_size:    322122547200  # 322122547200 bytes = 300 GiB
   dua_email_from:       no-reply-merritt@ucop.edu
   mrt_dua_file:         producer/mrt-dua.txt
 
 development: &development
   <<: *defaults
-  max_archive_size:     536870912 
+  max_archive_size:     536870912  # 536870912 bytes = 512 MiB
+  max_download_size:    161061273600  # 161061273600 bytes = 150 GiB
   dua_email_to:         [marisa.strong@ucop.edu]
   lostorage_email_to:   [marisa.strong@ucop.edu]
   lostorage_email_from: marisa.strong@ucop.edu
@@ -55,6 +58,7 @@ production_development:
 
 test:
   <<: *development
-  max_archive_size: 999999
+  max_archive_size:  999999  # 999999 bytes ~= 976.6 KiB
+  max_download_size: 104857600  # 104857600 bytes = 100 MiB
 local:
   <<: *development

--- a/public/403.html
+++ b/public/403.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Forbidden (403)</title>
+  <style type="text/css">
+    body { background-color: #fff; color: #666; text-align: center; font-family: arial, sans-serif; }
+    div.dialog {
+      width: 25em;
+      padding: 0 4em;
+      margin: 4em auto 0 auto;
+      border: 1px solid #ccc;
+      border-right-color: #999;
+      border-bottom-color: #999;
+    }
+    h1 { font-size: 100%; color: #f00; line-height: 1.5em; }
+  </style>
+</head>
+
+<body>
+  <!-- This file lives in public/403.html -->
+  <div class="dialog">
+    <h1>Forbidden</h1>
+    <p>You are forbidden to view this page.</p>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Rename `exceeds_size` methods that check `APP_CONFIG['max_archive_size']` to `exceeds_sync_size`
- Add `APP_CONFIG['max_download_size']`
- Add `exceeds_download_size` methods for object, version, and file
- Check `exceeds_download_size` before displaying an object or version download button, and before displaying a file download link
- Check `exceeds_download_size` in controller methods that download an object, version, or file, and return **403 Forbidden** if necessary

### File too large

> ![file-too-large](https://user-images.githubusercontent.com/10374934/39327586-4e71c8b0-494d-11e8-9951-92089461fee0.png)

### Object too large

> ![object-too-large](https://user-images.githubusercontent.com/10374934/39327574-48b383c8-494d-11e8-9153-df97929dde2c.png)

### Version (and file) too large

> ![version-too-large](https://user-images.githubusercontent.com/10374934/39327480-fbb73128-494c-11e8-8ab6-38e386378241.png)
