### PR TITLE
Validate page parameter and log errors

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,7 +10,9 @@ end
 class ApplicationController < ActionController::Base
   include DuaMixin
   include Encoder
+  include ErrorMixin
   include NumberMixin
+  include PaginationMixin
 
   helper_method(
     :available_groups,
@@ -30,11 +32,11 @@ class ApplicationController < ActionController::Base
   end
 
   # there are supposed to be handled by Rails, but 401 is not.
-  rescue_from ActiveResource::UnauthorizedAccess do |_ex|
+  rescue_from ActiveResource::UnauthorizedAccess do |ex|
     render file: "#{Rails.root}/public/401.html", status: 401, layout: nil
   end
 
-  rescue_from ActiveRecord::RecordNotFound do |_ex|
+  rescue_from ActiveRecord::RecordNotFound do |ex|
     render file: "#{Rails.root}/public/404.html", status: 404, layout: nil
   end
 
@@ -133,10 +135,6 @@ class ApplicationController < ActionController::Base
 
   def params_u(param)
     urlunencode(params[param])
-  end
-
-  def paginate_args
-    { page: (params[:page] || 1), per_page: 10 }
   end
 
   def stream_response(url, disposition, filename, mediatype, length = nil)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -32,11 +32,11 @@ class ApplicationController < ActionController::Base
   end
 
   # there are supposed to be handled by Rails, but 401 is not.
-  rescue_from ActiveResource::UnauthorizedAccess do |ex|
+  rescue_from ActiveResource::UnauthorizedAccess do |_ex|
     render file: "#{Rails.root}/public/401.html", status: 401, layout: nil
   end
 
-  rescue_from ActiveRecord::RecordNotFound do |ex|
+  rescue_from ActiveRecord::RecordNotFound do |_ex|
     render file: "#{Rails.root}/public/404.html", status: 404, layout: nil
   end
 

--- a/lib/error_mixin.rb
+++ b/lib/error_mixin.rb
@@ -1,0 +1,10 @@
+module ErrorMixin
+  def to_msg(error)
+    msg = "#{error.class}: #{error}"
+    if (backtrace = (error.respond_to?(:backtrace) && error.backtrace))
+      backtrace.each { |line| msg << "\n" << line }
+    end
+    return msg unless (cause = (error.respond_to?(:cause) && error.cause))
+    msg << "\nCaused by: " << to_msg(cause)
+  end
+end

--- a/lib/pagination_mixin.rb
+++ b/lib/pagination_mixin.rb
@@ -2,12 +2,15 @@ module PaginationMixin
   include ErrorMixin
 
   def page_param
-    param = params[:page]
-    return unless param
-    page = Integer(param)
-    page >= 1 ? page : 1
-  rescue StandardError => e
-    logger.error(to_msg(e))
+    begin
+      param = params[:page]
+      return unless param
+      page = Integer(param)
+      return page unless page <= 1
+      logger.warn("Can't show page #{page}; showing page 1")
+    rescue StandardError => e
+      logger.error(to_msg(e))
+    end
     1
   end
 

--- a/lib/pagination_mixin.rb
+++ b/lib/pagination_mixin.rb
@@ -1,0 +1,17 @@
+module PaginationMixin
+  include ErrorMixin
+
+  def page_param
+    param = params[:page]
+    return unless param
+    page = Integer(param)
+    page >= 1 ? page : 1
+  rescue StandardError => e
+    logger.error(to_msg(e))
+    1
+  end
+
+  def paginate_args
+    { page: page_param, per_page: 10 }
+  end
+end

--- a/spec/libs/error_mixin_spec.rb
+++ b/spec/libs/error_mixin_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+describe ErrorMixin do
+  include ErrorMixin
+
+  it 'handles nil' do
+    expect(to_msg(nil)).to include(nil.class.to_s)
+  end
+
+  it 'handles raw strings' do
+    str = 'a string'
+    expect(to_msg(str)).to include(str)
+  end
+
+  it 'handles exceptions' do
+    err_class = StandardError
+    err_msg = 'Help I am trapped in a unit test'
+    full_msg = nil
+    begin
+      raise err_class, err_msg
+    rescue StandardError => e
+      full_msg = to_msg(e)
+    end
+    expect(full_msg).to include(err_class.to_s)
+    expect(full_msg).to include(err_msg)
+    expect(full_msg).to include(__FILE__)
+  end
+
+  it 'handles nested exceptions' do
+    inner_class = ArgumentError
+    inner_msg = 'Help I am trapped in a nested exception'
+    outer_class = StandardError
+    outer_msg = 'Help I am a nested exception'
+    full_msg = nil
+    begin
+      begin
+        raise inner_class, inner_msg
+      rescue StandardError
+        raise outer_class, outer_msg
+      end
+    rescue StandardError => e
+      full_msg = to_msg(e)
+    end
+    expect(full_msg).to include(inner_class.to_s)
+    expect(full_msg).to include(inner_msg)
+    expect(full_msg).to include(outer_class.to_s)
+    expect(full_msg).to include(outer_msg)
+    expect(full_msg).to include(__FILE__)
+    puts(full_msg)
+  end
+
+end

--- a/spec/libs/error_mixin_spec.rb
+++ b/spec/libs/error_mixin_spec.rb
@@ -46,7 +46,6 @@ describe ErrorMixin do
     expect(full_msg).to include(outer_class.to_s)
     expect(full_msg).to include(outer_msg)
     expect(full_msg).to include(__FILE__)
-    puts(full_msg)
   end
 
 end

--- a/spec/libs/pagination_mixin_spec.rb
+++ b/spec/libs/pagination_mixin_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+describe PaginationMixin do
+  include PaginationMixin
+
+  attr_reader :logger
+  attr_reader :params
+
+  before(:each) do
+    @logger = instance_double(Logger)
+    @params = {}
+  end
+
+  describe ':page_param' do
+    it 'parses an int' do
+      an_int = 17
+      params[:page] = an_int.to_s
+      expect(page_param).to eq(an_int)
+    end
+
+    it 'parses 0 as 1' do
+      zero = 0.to_s
+      params[:page] = zero
+      expect(logger).to receive(:warn).once do |m|
+        expect(m).to include(zero)
+      end
+      expect(page_param).to eq(1)
+    end
+
+    it 'parses negative number as 1' do
+      negative = -17.to_s
+      params[:page] = negative
+      expect(logger).to receive(:warn).once do |m|
+        expect(m).to include(negative)
+      end
+      expect(page_param).to eq(1)
+    end
+
+    it 'parses garbage as 1 and logs the error' do
+      garbage = 'garbage'
+      params[:page] = garbage
+      expect(logger).to(receive(:error)).once do |m|
+        expect(m).to include(garbage)
+      end
+      expect(page_param).to eq(1)
+    end
+
+    it 'handles previously parsed ints transparently' do
+      an_int = 17
+      params[:page] = an_int
+      expect(page_param).to eq(an_int)
+    end
+  end
+end


### PR DESCRIPTION
Fix for #13:

- Preemptively tries to parse the page number parameter (`:page`) and if it doesn’t parse, logs an error and defaults to page 1, but doesn't display an error page / send an email.
- If the page number parameter is zero or negative, logs a warning and defaults to page 1.
- Adds `ErrorMixin` for logging full stack traces with cause. (Why Ruby doesn't do this out of the box is beyond me.)
- Moves pagination-related code out of ApplicationController into `PaginationMixin` to keep the controller class from getting any bigger.
- Adds specs for `ErrorMixin` and `PaginationMixin`.