### PR TITLE
Version permissions

### DIFF
--- a/app/controllers/version_controller.rb
+++ b/app/controllers/version_controller.rb
@@ -37,7 +37,9 @@ class VersionController < ApplicationController
     raise ActiveRecord::RecordNotFound if @version.nil?
   end
 
-  def index; end
+  def index
+    render(file: "#{Rails.root}/public/401.html", status: 401, layout: false) unless @version.inv_object.user_has_read_permission?(current_uid)
+  end
 
   def async
     if @version.exceeds_download_size?

--- a/app/views/object/index.html.erb
+++ b/app/views/object/index.html.erb
@@ -20,15 +20,21 @@
     <%= render :partial => 'details_display', :object => @object %>
 
     <div class="form-submit">
-      <% if @object.exceeds_download_size? %>
+      <% if current_user_can_download?(@object) %>
+        <% if @object.exceeds_download_size? %>
+          <p>
+            Objects larger than <%= max_download_size_pretty %> cannot be downloaded as a .zip file.
+            Versions and individual files below that size can still be downloaded.
+          </p>
+        <% else %>
+          <form action="<%= url_for(:action => :download, :object => @object) %>">
+            <input type="submit" value="Download object">
+          </form>
+        <% end %>
+      <% else %>
         <p>
-          Objects larger than <%= max_download_size_pretty %> cannot be downloaded as a .zip file.
-          Versions and individual files below that size can still be downloaded.
+          You do not have permission to download this object.
         </p>
-      <% elsif current_user_can_download?(@object) then %>
-        <form action="<%= url_for(:action => :download, :object => @object) %>">
-          <input type="submit" value="Download object">
-        </form>
       <% end %>
     </div>
 

--- a/app/views/version/index.html.erb
+++ b/app/views/version/index.html.erb
@@ -48,15 +48,21 @@
     </table>
 
     <div class="form-submit">
-      <% if @version.exceeds_download_size? %>
+      <% if current_user_can_download?(@version.inv_object) %>
+        <% if @version.exceeds_download_size? %>
+          <p>
+            Versions larger than <%= max_download_size_pretty %> cannot be downloaded as a .zip file.
+            Versions and individual files below that size can still be downloaded.
+          </p>
+        <% else %>
+          <form action="<%= url_for(:action => :download, :object => @version.inv_object, :version => @version) %>">
+            <input type="submit" value="Download version">
+          </form>
+        <% end %>
+      <% else %>
         <p>
-          Versions larger than <%= max_download_size_pretty %> cannot be downloaded as a .zip file.
-          Versions and individual files below that size can still be downloaded.
+          You do not have permission to download this object.
         </p>
-      <% elsif current_user_can_download?(@version.inv_object) then %>
-        <form action="<%= url_for(:action => :download, :object => @version.inv_object, :version => @version) %>">
-          <input type="submit" value="Download version">
-        </form>
       <% end %>
     </div>
   </section>

--- a/spec/features/object_spec.rb
+++ b/spec/features/object_spec.rb
@@ -140,10 +140,10 @@ describe 'objects' do
     log_in_with(user_id, password)
 
     index_path = url_for(
-        controller: :object,
-        action: :index,
-        object: obj.ark,
-        only_path: true
+      controller: :object,
+      action: :index,
+      object: obj.ark,
+      only_path: true
     )
     visit(index_path)
 

--- a/spec/features/object_spec.rb
+++ b/spec/features/object_spec.rb
@@ -5,6 +5,7 @@ describe 'objects' do
   attr_reader :password
   attr_reader :obj
   attr_reader :version_str
+  attr_reader :collection_1_id
 
   attr_reader :producer_files
   attr_reader :system_files
@@ -14,7 +15,7 @@ describe 'objects' do
     @user_id = mock_user(name: 'Jane Doe', password: password)
 
     inv_collection_1 = create(:inv_collection, name: 'Collection 1', mnemonic: 'collection_1')
-    collection_1_id = mock_ldap_for_collection(inv_collection_1)
+    @collection_1_id = mock_ldap_for_collection(inv_collection_1)
     mock_permissions_all(user_id, collection_1_id)
 
     @obj = create(:inv_object, erc_who: 'Doe, Jane', erc_what: 'Object 1', erc_when: '2018-01-01')
@@ -60,6 +61,56 @@ describe 'objects' do
     expect(page.title).to include('Object')
     expect(page.title).to include(obj.ark)
     expect(page).to have_content("Object: #{obj.ark}")
+  end
+
+  it 'requires view permissions' do
+    user_id = mock_user(name: 'Rachel Roe', password: password)
+    expect(obj.user_has_read_permission?(user_id)).to eq(false) # just to be sure
+
+    log_out!
+    log_in_with(user_id, password)
+
+    index_path = url_for(
+      controller: :object,
+      action: :index,
+      object: obj.ark,
+      only_path: true
+    )
+    visit(index_path)
+
+    expect(page.title).to include('401')
+    expect(page).to have_content('not authorized')
+  end
+
+  it 'automatically logs in as guest' do
+    mock_permissions_read_only(LDAP_CONFIG['guest_user'], collection_1_id)
+
+    log_out!
+    index_path = url_for(
+      controller: :object,
+      action: :index,
+      object: obj.ark,
+      only_path: true
+    )
+    visit(index_path)
+    expect(page).to have_content('Logged in as Guest')
+    expect(page).to have_content('You must be logged in to access the page you requested')
+  end
+
+  it 'requires view permissions even for guest auto-login' do
+    expect(obj.user_has_read_permission?(LDAP_CONFIG['guest_user'])).to eq(false) # just to be sure
+
+    log_out!
+    index_path = url_for(
+      controller: :object,
+      action: :index,
+      object: obj.ark,
+      only_path: true
+    )
+    visit(index_path)
+
+    expect(page.title).to include('401')
+    expect(page).to have_content('not authorized')
   end
 
   it 'should display minimal metadata' do

--- a/spec/features/object_spec.rb
+++ b/spec/features/object_spec.rb
@@ -132,6 +132,25 @@ describe 'objects' do
     expect(URI(download_action).path).to eq(URI(expected_uri).path)
   end
 
+  it 'should not display a download button w/o download permission' do
+    user_id = mock_user(name: 'Rachel Roe', password: password)
+    mock_permissions_view_only(user_id, collection_1_id)
+
+    log_out!
+    log_in_with(user_id, password)
+
+    index_path = url_for(
+        controller: :object,
+        action: :index,
+        object: obj.ark,
+        only_path: true
+    )
+    visit(index_path)
+
+    expect(page).not_to have_content('Download object')
+    expect(page).to have_content('You do not have permission to download this object.')
+  end
+
   describe 'version info' do
     it 'should display the version' do
       expect(page).to have_content(version_str)

--- a/spec/features/version_spec.rb
+++ b/spec/features/version_spec.rb
@@ -6,6 +6,7 @@ describe 'versions' do
   attr_reader :obj
   attr_reader :version_str
   attr_reader :version
+  attr_reader :collection_1_id
 
   attr_reader :producer_files
   attr_reader :system_files
@@ -15,7 +16,7 @@ describe 'versions' do
     @user_id = mock_user(name: 'Jane Doe', password: password)
 
     inv_collection_1 = create(:inv_collection, name: 'Collection 1', mnemonic: 'collection_1')
-    collection_1_id = mock_ldap_for_collection(inv_collection_1)
+    @collection_1_id = mock_ldap_for_collection(inv_collection_1)
     mock_permissions_all(user_id, collection_1_id)
 
     @obj = create(:inv_object, erc_who: 'Doe, Jane', erc_what: 'Object 1', erc_when: '2018-01-01')
@@ -62,6 +63,59 @@ describe 'versions' do
   it 'should be the version page' do
     expect(page.title).to include(version_str)
     expect(page.title).to include(obj.ark)
+  end
+
+  it 'requires view permissions' do
+    user_id = mock_user(name: 'Rachel Roe', password: password)
+    expect(obj.user_has_read_permission?(user_id)).to eq(false) # just to be sure
+
+    log_out!
+    log_in_with(user_id, password)
+
+    index_path = url_for(
+      controller: :version,
+      action: :index,
+      object: obj.ark,
+      version: version.number,
+      only_path: true
+    )
+    visit(index_path)
+
+    expect(page.title).to include('401')
+    expect(page).to have_content('not authorized')
+  end
+
+  it 'automatically logs in as guest' do
+    mock_permissions_read_only(LDAP_CONFIG['guest_user'], collection_1_id)
+
+    log_out!
+    index_path = url_for(
+      controller: :version,
+      action: :index,
+      object: obj.ark,
+      version: version.number,
+      only_path: true
+    )
+    visit(index_path)
+    expect(page).to have_content('Logged in as Guest')
+    expect(page).to have_content('You must be logged in to access the page you requested')
+  end
+
+  it 'requires view permissions even for guest auto-login' do
+    expect(obj.user_has_read_permission?(LDAP_CONFIG['guest_user'])).to eq(false) # just to be sure
+
+    log_out!
+    index_path = url_for(
+      controller: :version,
+      action: :index,
+      object: obj.ark,
+      version: version.number,
+      only_path: true
+    )
+    visit(index_path)
+
+    expect(page.title).to include('401')
+    expect(page).to have_content('not authorized')
   end
 
   describe 'without specified version' do

--- a/spec/features/version_spec.rb
+++ b/spec/features/version_spec.rb
@@ -154,11 +154,11 @@ describe 'versions' do
     log_in_with(user_id, password)
 
     index_path = url_for(
-        controller: :version,
-        action: :index,
-        object: obj.ark,
-        version: version.number,
-        only_path: true
+      controller: :version,
+      action: :index,
+      object: obj.ark,
+      version: version.number,
+      only_path: true
     )
     visit(index_path)
 
@@ -174,11 +174,11 @@ describe 'versions' do
     log_in_with(user_id, password)
 
     index_path = url_for(
-        controller: :version,
-        action: :index,
-        object: obj.ark,
-        version: version.number,
-        only_path: true
+      controller: :version,
+      action: :index,
+      object: obj.ark,
+      version: version.number,
+      only_path: true
     )
     visit(index_path)
 

--- a/spec/support/ldap.rb
+++ b/spec/support/ldap.rb
@@ -7,6 +7,7 @@ require 'support/ark'
 GUEST_USER_ID = 'anonymous'.freeze
 PERMISSIONS_ALL = %w[read write download admin].freeze
 PERMISSIONS_READ_ONLY = %w[read download].freeze
+PERMISSIONS_VIEW_ONLY = %w[read].freeze
 
 def to_id(name)
   name.gsub(/[^A-Za-z0-9_]+/, '_').underscore
@@ -77,6 +78,11 @@ end
 def mock_permissions_read_only(user_id, group_id_or_ids)
   gids = Array(group_id_or_ids)
   mock_permissions(user_id, gids.map { |gid| [gid, PERMISSIONS_READ_ONLY] }.to_h)
+end
+
+def mock_permissions_view_only(user_id, group_id_or_ids)
+  gids = Array(group_id_or_ids)
+  mock_permissions(user_id, gids.map { |gid| [gid, PERMISSIONS_VIEW_ONLY] }.to_h)
 end
 
 def mock_permissions(user_id, perms_by_group_id)


### PR DESCRIPTION
1. Checks that user has read permissions before displaying version page, and if not, returns a 401 error instead.
2. On both version and object pages, if user has read permissions but not download permissions, displays “You do not have permission to download this object” (instead of a download button).
3. Adds feature tests for the above, as well as related features around object page permissions and guest user auto-login.