### PR TITLE
Use private config repo instead of hard-coded config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,3 +203,41 @@ The Travis build is configured in the [`.travis.yml`](.travis.yml) file.
 It's a simple build, using the [`travis-prep.sh`](travis-prep.sh) script to
 set up the test database and test configuration files, and then running
 `bundle exec rake` -- the Travis default for a Ruby project.
+
+## Deployment
+
+This project is deployed with [Capistrano](https://capistranorb.com), as controlled
+by the [`config/deploy.rb`](config/deploy.rb) file. Note that the "environments"
+for Capistrano purposes are the individual servers, as defined in the
+[`config/deploy`](config/deploy) directory.
+
+### Configuration
+
+Configuration for this project is stored in the `mrt-dashboard-config`
+[private repository](https://github.com/cdlib/mrt-dashboard-config).
+
+The configuration directory is are deployed by default as part of the
+`mrt-dashboard` Capistrano deployment.
+
+- To redeploy a change to the config files without redeploying the code,
+  you can use `cap <ENV> deploy:update_config` in the `mrt-dashboard`
+  project. (You'll probably then also want to run `cap <ENV> deploy:stop;
+  cap <ENV> deploy:start`, so that the application will pick up the
+  changes.)
+- To deploy a specific tag (not branch!) of this config repository, you
+  can use the `$CONF_TAG` environment variable, either in a standalone
+  config deployment:
+
+  ```
+  CONF_TAG=<config tag> cap <ENV> deploy:update_config
+  ```
+
+  or in a deployment of the code:
+
+  ```
+  CONF_TAG=<config tag> [TAG=<code tag>] cap <ENV> deploy
+  ````
+
+  Note that you can separately specify the tag for the code itself with
+  `$TAG`.
+

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -71,7 +71,7 @@ namespace :deploy do
   desc 'Prompt for branch'
   task :prompt_for_tag do
     on roles(:app) do
-      puts 'Usage: TAG=test cap mrt-ui-dev deploy'
+      puts 'Usage: [CONF_TAG=<config repo tag>] TAG=<UI repo tag> cap mrt-ui-dev deploy'
       ask :branch, 'master' unless ENV['TAG']
       set :branch, ENV['TAG'] if ENV['TAG']
       puts "Setting branch to: #{fetch(:branch)}"
@@ -97,10 +97,18 @@ namespace :deploy do
         end
       end
 
-      config_branch = fetch(:config_branch, 'master')
+      if ENV['CONF_TAG']
+        set :config_tag, ENV['CONF_TAG']
+        puts "Setting #{config_repo} tag to: #{fetch(:config_tag)}"
+      else
+        puts "Defaulting #{config_repo} to master"
+      end
+      
+      config_tag = fetch(:config_tag, 'master')
       within "#{shared_dir}/#{config_repo}" do
+        puts "Updating #{config_repo} to #{config_tag}"
         execute 'git', 'fetch', '--all', '--tags'
-        execute 'git', 'reset', '--hard', config_branch
+        execute 'git', 'reset', '--hard', config_tag
       end
     end
   end

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -85,6 +85,11 @@ namespace :deploy do
 
       shared_dir = "#{deploy_to}/shared"
       if test("[ ! -d #{shared_dir}/#{config_repo} ]")
+        config_dir = "#{shared_dir}/config"
+        if test("[ -d #{config_dir} ]")
+          # move hard-coded config directory out of the way
+          execute "mv #{config_dir} #{config_dir}.old"
+        end
         within shared_dir do
           # clone config repo and link it as config directory
           execute 'git', 'clone', "git@github.com:cdlib/#{config_repo}"

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -90,9 +90,7 @@ namespace :deploy do
       unless test("[ -d #{shared_dir}/#{config_repo} ]")
         # move hard-coded config directory out of the way if needed
         config_dir = "#{shared_dir}/config"
-        if test("[ -d #{config_dir} ]")
-          execute "mv #{config_dir} #{config_dir}.old"
-        end
+        execute "mv #{config_dir} #{config_dir}.old" if test("[ -d #{config_dir} ]")
         within shared_dir do
           # clone config repo and link it as config directory
           execute 'git', 'clone', "git@github.com:cdlib/#{config_repo}"

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -83,13 +83,14 @@ namespace :deploy do
   desc 'Update configuration'
   task :update_config do
     on roles(:app) do
+      shared_dir = "#{deploy_to}/shared"
       config_repo = 'mrt-dashboard-config'
 
-      shared_dir = "#{deploy_to}/shared"
+      # make sure config repo is checked out & symlinked
       unless test("[ -d #{shared_dir}/#{config_repo} ]")
+        # move hard-coded config directory out of the way if needed
         config_dir = "#{shared_dir}/config"
         if test("[ -d #{config_dir} ]")
-          # move hard-coded config directory out of the way
           execute "mv #{config_dir} #{config_dir}.old"
         end
         within shared_dir do
@@ -99,13 +100,15 @@ namespace :deploy do
         end
       end
 
+      # check for specific config repo tag
       if ENV['CONF_TAG']
         set :config_tag, ENV['CONF_TAG']
         puts "Setting #{config_repo} tag to: #{fetch(:config_tag)}"
       else
         puts "Defaulting #{config_repo} to master"
       end
-      
+
+      # update config repo
       config_tag = fetch(:config_tag, 'master')
       within "#{shared_dir}/#{config_repo}" do
         puts "Updating #{config_repo} to #{config_tag}"

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -111,7 +111,7 @@ namespace :deploy do
       within "#{shared_dir}/#{config_repo}" do
         puts "Updating #{config_repo} to #{config_tag}"
         execute 'git', 'fetch', '--all', '--tags'
-        execute 'git', 'reset', '--hard', config_tag
+        execute 'git', 'reset', '--hard', "origin/#{config_tag}"
       end
     end
   end

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -78,6 +78,19 @@ namespace :deploy do
     end
   end
 
+  desc 'Update configuration'
+  task :update_config do
+    on roles(:app) do
+      config_repo = 'mrt-dashboard-config'
+
+      config_branch = fetch(:config_branch, 'master')
+      within "#{shared_dir}/#{config_repo}" do
+        execute 'git', 'fetch', '--all', '--tags'
+        execute 'git', 'reset', '--hard', config_branch
+      end
+    end
+  end
+
 end
 
 namespace :bundle do

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -83,6 +83,15 @@ namespace :deploy do
     on roles(:app) do
       config_repo = 'mrt-dashboard-config'
 
+      shared_dir = "#{deploy_to}/shared"
+      if test("[ ! -d #{shared_dir}/#{config_repo} ]")
+        within shared_dir do
+          # clone config repo and link it as config directory
+          execute 'git', 'clone', "git@github.com:cdlib/#{config_repo}"
+          execute 'ln', '-s', config_repo, 'config'
+        end
+      end
+
       config_branch = fetch(:config_branch, 'master')
       within "#{shared_dir}/#{config_repo}" do
         execute 'git', 'fetch', '--all', '--tags'

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -29,6 +29,8 @@ set :keep_releases, 5
 
 # Prompt for TAG before deployment only
 before 'deploy', 'deploy:prompt_for_tag'
+# Update config repo before deployment only
+before 'deploy', 'deploy:update_config'
 
 namespace :deploy do
 
@@ -84,7 +86,7 @@ namespace :deploy do
       config_repo = 'mrt-dashboard-config'
 
       shared_dir = "#{deploy_to}/shared"
-      if test("[ ! -d #{shared_dir}/#{config_repo} ]")
+      unless test("[ -d #{shared_dir}/#{config_repo} ]")
         config_dir = "#{shared_dir}/config"
         if test("[ -d #{config_dir} ]")
           # move hard-coded config directory out of the way


### PR DESCRIPTION
This pull request updates the Capistrano deploy process to pull from the private [cdlib/mrt-dashboard-config](https://github.com/cdlib/mrt-dashboard-config) repository.

1. if a plain `shared/config` directory exists on the server, it is renamed to `config.old`.
2. if `mrt-dashboard-config` hasn't been cloned:
   - we clone it as `shared/mrt-dashboard-config`
   - we symlink `shared/config` to `shared/mrt-dashboard-config`
3. we use `git fetch` and `git reset --hard` to update the cloned `mrt-dashboard-config`

By default, we use the `master` branch of `mrt-dashboard-config`. We don't prompt for a config tag, but we can specify one, distinct from the tag for the code itself, with the `$CONF_TAG` environment variable, e.g.

```
   CONF_TAG=2018.6.1.alpha TAG=2018.6 cap mrt-ui-dev deploy
```

Note that unlike [Dash](https://github.com/CDLUC3/dashv2/blob/v0.2.30/config/deploy.rb#L78-L87):
- we don't support branches, just tags
- we don't assume the config repo has a tag with the same name as the code repo, or even that it's been tagged at all