### PR TITLE
Don't sleep between batches if anything in the batch was already up to date

### DIFF
--- a/lib/merritt/atom/entry_processor.rb
+++ b/lib/merritt/atom/entry_processor.rb
@@ -18,7 +18,7 @@ module Merritt
       end
 
       def process_entry!
-        return if existing_object && existing_object.modified >= atom_updated
+        return if already_up_to_date?
         obj = new_ingest_object
         links.each { |link| add_component(obj, link) }
         harvester.start_ingest(obj)
@@ -37,6 +37,10 @@ module Merritt
             primary_local_id
           end
         end
+      end
+
+      def already_up_to_date?
+        @already_up_to_date ||= existing_object && existing_object.modified >= atom_updated
       end
 
       private

--- a/lib/merritt/atom/feed_processor.rb
+++ b/lib/merritt/atom/feed_processor.rb
@@ -25,7 +25,7 @@ module Merritt
           any_up_to_date = process_batch(batch)
           no_more_batches = batches.size <= i + 1
           next if any_up_to_date || no_more_batches
-          sleep(harvester.delay) unless no_more_batches
+          sleep(harvester.delay)
         end
         PageResult.new(atom_updated: atom_updated, next_page: next_page)
       end

--- a/lib/merritt/atom/feed_processor.rb
+++ b/lib/merritt/atom/feed_processor.rb
@@ -22,14 +22,25 @@ module Merritt
         return if feed_updated < harvester.last_feed_update
         batches = atom_xml.xpath('//atom:entry', NS).each_slice(harvester.batch_size)
         batches.each_with_index do |batch, i|
-          batch.each { |entry| process_entry(entry) }
-          sleep(harvester.delay) if i + 1 < batches.size
+          any_up_to_date = process_batch(batch)
+          no_more_batches = batches.size <= i + 1
+          next if any_up_to_date || no_more_batches
+          sleep(harvester.delay) unless no_more_batches
         end
         PageResult.new(atom_updated: atom_updated, next_page: next_page)
       end
       # rubocop:enable Metrics/AbcSize
 
       private
+
+      def process_batch(batch)
+        any_up_to_date = false
+        batch.each do |entry|
+          entry_up_to_date = process_entry(entry)
+          any_up_to_date ||= entry_up_to_date
+        end
+        any_up_to_date
+      end
 
       def verify_collection_id!
         expected_id = harvester.collection_ark
@@ -46,6 +57,7 @@ module Merritt
         atom_id = entry_processor.atom_id
         local_id = entry_processor.local_id
         entry_processor.process_entry!
+        entry_processor.already_up_to_date?
       rescue StandardError => e
         atom_id_str = atom_id || '(unknown)'
         local_id_str = local_id || '(unknown)'


### PR DESCRIPTION
`EntryProcessor.process_entry!` already checks whether an object was up to date, and if so, skips ingest for that object.

This change has `process_entry!` return `true` if the entry was already up to date, and `false` otherwise. If any entries in a batch are up to date, `FeedProcessor.process_xml!` will proceed immediately to the next batch without sleeping.