### PR TITLE
Removing inactive recipients from object download email config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,9 @@ cache:
   bundler: true
 
 before_install:
-  # Wait for mysql service to respond
+  # start mysql
+  - sudo systemctl start mysql
+  # wait for mysql service to respond
   - which mysql && until mysql -u root -e "show status" &>/dev/null; do sleep 1; done
   # set up MySQL 5.7
   - sudo mysql -e "use mysql; update user set authentication_string=PASSWORD('') where User='root'; update user set plugin='mysql_native_password';FLUSH PRIVILEGES;"

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ addons:
     packages:
       - mysql-server
       - mysql-client
+      - xvfb
 
 language: ruby
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,25 @@
 sudo: false
-dist: trusty
+dist: xenial
 
 notifications:
   email:
     recipients:
-      - david.moles@ucop.edu
       - mark.reyes@ucop.edu
+      - terrence.brady@ucop.edu
+      - eric.lopatin@ucop.edu
+
+serices:
+  - mysql
 
 addons:
   chrome: stable
   apt:
     update: true
-    sources:
-      - mysql-5.7-trusty
-    packages:
-      - mysql-server
-      - mysql-client
+    # sources:
+    #   - mysql-5.7-trusty
+    # packages:
+    #   - mysql-server
+    #   - mysql-client
 
 language: ruby
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,5 +48,5 @@ before_script:
 
   # set up xvfb and give it some time to start
   - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
+  # - "sh -e /etc/init.d/xvfb start"
   - "while [ ! -e /tmp/.X11-unix/X99 ]; do sleep 1; done"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ serices:
 notifications:
   email:
     recipients:
-      - mark.reyes@ucop.edu
-      - terrence.brady@ucop.edu
+      # - mark.reyes@ucop.edu
+      # - terrence.brady@ucop.edu
       - eric.lopatin@ucop.edu
 
 addons:
@@ -48,5 +48,6 @@ before_script:
 
   # set up xvfb and give it some time to start
   - "export DISPLAY=:99.0"
+  - Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
   # - "sh -e /etc/init.d/xvfb start"
   # - "while [ ! -e /tmp/.X11-unix/X99 ]; do sleep 1; done"

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,9 @@ addons:
     update: true
     # sources:
     #   - mysql-5.7-trusty
-    # packages:
-    #   - mysql-server
-    #   - mysql-client
+    packages:
+      - mysql-server
+      - mysql-client
 
 language: ruby
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ dist: xenial
 
 serices:
   - mysql
+  - xvfb
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,12 +16,10 @@ addons:
   chrome: stable
   apt:
     update: true
-    # sources:
-    #   - mysql-5.7-trusty
-    packages:
-      - mysql-server
-      - mysql-client
-      - xvfb
+    # packages:
+    #   - mysql-server
+    #   - mysql-client
+    #   - xvfb
 
 language: ruby
 
@@ -46,9 +44,6 @@ before_install:
 before_script:
   # run travis-prep.sh
   - ./travis-prep.sh
-
-  # set up xvfb and give it some time to start
+  # set up xvfb
   - "export DISPLAY=:99.0"
   - Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
-  # - "sh -e /etc/init.d/xvfb start"
-  # - "while [ ! -e /tmp/.X11-unix/X99 ]; do sleep 1; done"

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,4 +49,4 @@ before_script:
   # set up xvfb and give it some time to start
   - "export DISPLAY=:99.0"
   # - "sh -e /etc/init.d/xvfb start"
-  - "while [ ! -e /tmp/.X11-unix/X99 ]; do sleep 1; done"
+  # - "while [ ! -e /tmp/.X11-unix/X99 ]; do sleep 1; done"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,18 +8,14 @@ serices:
 notifications:
   email:
     recipients:
-      # - mark.reyes@ucop.edu
-      # - terrence.brady@ucop.edu
+      - mark.reyes@ucop.edu
+      - terrence.brady@ucop.edu
       - eric.lopatin@ucop.edu
 
 addons:
   chrome: stable
   apt:
     update: true
-    # packages:
-    #   - mysql-server
-    #   - mysql-client
-    #   - xvfb
 
 language: ruby
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,8 @@ cache:
   bundler: true
 
 before_install:
+  # Wait for mysql service to respond
+  - which mysql && until mysql -u root -e "show status" &>/dev/null; do sleep 1; done
   # set up MySQL 5.7
   - sudo mysql -e "use mysql; update user set authentication_string=PASSWORD('') where User='root'; update user set plugin='mysql_native_password';FLUSH PRIVILEGES;"
   - sudo mysql_upgrade -u root

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,15 @@
 sudo: false
 dist: xenial
 
+serices:
+  - mysql
+
 notifications:
   email:
     recipients:
       - mark.reyes@ucop.edu
       - terrence.brady@ucop.edu
       - eric.lopatin@ucop.edu
-
-serices:
-  - mysql
 
 addons:
   chrome: stable

--- a/config/app_config.yml
+++ b/config/app_config.yml
@@ -25,8 +25,8 @@ development: &development
 
 stage:
   <<: *defaults
-  dua_email_to:         [marisa.strong@ucop.edu, perry.willett@ucop.edu, eric.lopatin@ucop.edu]
-  lostorage_email_to:   [marisa.strong@ucop.edu, perry.willett@ucop.edu, eric.lopatin@ucop.edu]
+  dua_email_to:         [marisa.strong@ucop.edu, eric.lopatin@ucop.edu]
+  lostorage_email_to:   [marisa.strong@ucop.edu, eric.lopatin@ucop.edu]
   lostorage_email_from: uc3@ucop.edu
   merritt_server:       "http://merritt-stage.cdlib.org"
   container_url:        "http://merritt-stage.cdlib.org/cloudcontainer/"
@@ -41,7 +41,7 @@ stage:
 production:
   <<: *defaults
   dua_email_to:         [uc3@ucop.edu]
-  lostorage_email_to:   [marisa.strong@ucop.edu, david.moles@ucop.edu, perry.willett@ucop.edu, jim.vanderveen@ucop.edu, eric.lopatin@ucop.edu]
+  lostorage_email_to:   [marisa.strong@ucop.edu, eric.lopatin@ucop.edu]
   lostorage_email_from: uc3@ucop.edu
   merritt_server:       "http://merritt.cdlib.org"
   container_url:        "http://merritt.cdlib.org/cloudcontainer/"


### PR DESCRIPTION
Removing inactive recipients from object download email. Also fixed build by moving to use of Xenial (Ubuntu 16.04) for tests, which required new service and setup entries for mysql and xvfb in the Travis YAML file. 